### PR TITLE
EVM Endpoint Network Switcharoo Runbook

### DIFF
--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -15,3 +15,10 @@ Runbooks for upgrading EOS-EVM components and infrastructure.
 
 ## See Also
 - [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code
+
+***
+**_Legal notice_**  
+This document was generated in collaboration with ChatGPT from OpenAI, a machine learning algorithm or weak artificial intelligence (AI). At the time of this writing, the [OpenAI terms of service agreement](https://openai.com/terms) §3.a states:
+> Your Content. You may provide input to the Services (“Input”), and receive output generated and returned by the Services based on the Input (“Output”). Input and Output are collectively “Content.” As between the parties and to the extent permitted by applicable law, you own all Input, and subject to your compliance with these Terms, OpenAI hereby assigns to you all its right, title and interest in and to Output.
+
+This notice is required in some countries.

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -12,6 +12,8 @@ Our runbooks are as open as possible in the interest of transparency. However, r
 
 ## Upgrades
 Runbooks for upgrading EOS-EVM components and infrastructure.
+1. Endpoint Upgrade
+    1. [Endpoint Network Switcharoo](./endpoint-network-switcharoo.md) - deploy a set of virtual machines with upgraded software to our endpoints
 
 ## See Also
 - [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,0 +1,17 @@
+# Runbooks
+This folder contains runbooks for common EOS-EVM operations.
+
+_What are runbooks?_
+> Runbooks are a type of document or manual used in IT operations and other technical fields to outline the necessary steps and procedures for carrying out a particular process or task. They are often created to ensure consistency and reduce errors by providing a standardized set of instructions that can be followed by anyone responsible for performing the task. Runbooks can be created for a wide variety of tasks, such as system maintenance, software deployment, incident response, and disaster recovery. They typically include detailed instructions, checklists, and troubleshooting tips to help ensure that tasks are carried out efficiently and effectively.
+
+Our runbooks are as open as possible in the interest of transparency. However, runbooks may link to tables in private repos containing sensitive values where necessary. Secret values should never be committed to GitHub, secrets should be saved and shared using a password manager.
+
+### Index
+1. [Upgrades](#upgrades)
+1. [See Also](#see-also)
+
+## Upgrades
+Runbooks for upgrading EOS-EVM components and infrastructure.
+
+## See Also
+- [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -1,5 +1,5 @@
 # Endpoint Network Switcharoo
-This runbook explains how to take a new set of virtual machines running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
+This runbook explains how to take a new set of virtual machines (VMs) running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
 
 ### Index
 1. [Prerequisites](#prerequisites)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -12,7 +12,7 @@ This runbook is based on several assumptions that must be met.
 1. This upgrade has been approved by all relevant stakeholders.
 1. You have an Amazon Web Services (AWS) IAM user account with the necessary permissions to perform the upgrade(s) in the `evm-testnet` and/or `evm-mainnet` AWS accounts.
 1. The new virtual machine(s):
-    1. Are in the correct availability zones (AZs),
+    1. Are in the correct [availability zones](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md) (AZs),
     1. Have been initialized with upgraded software,
     1. Are prepared to pass health checks if they are functioning correctly, and;
     1. Will fail health checks if they are not functioning correctly.
@@ -20,7 +20,7 @@ This runbook is based on several assumptions that must be met.
 ## Steps
 Here are the steps to take a new set of virtual machines (VMs) running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
 1. Login to the [AWS web console](https://console.aws.amazon.com).
-1. Switch to the intended region in AWS.
+1. Switch to the intended [region in AWS](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md).
 1. Perform a smoke test on the existing endpoint to verify everything is working before making any changes.
     - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke test. After the smoke test, you can disconnect.
 1. Perform a smoke test on each and every individual virtual machine to verify the new virtual machines are working as expected.

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -2,7 +2,18 @@
 This runbook explains how to take an new set of virtual machines running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
 
 ### Index
+1. [Prerequisites](#prerequisites)
 1. [See Also](#see-also)
+
+## Prerequisites
+This runbook is based on several assumptions that must be met.
+1. This upgrade has been approved by all relevant stakeholders.
+1. You have an Amazon Web Services (AWS) IAM user account with the necessary permissions to perform the upgrade(s) in the `evm-testnet` and/or `evm-mainnet` AWS accounts.
+1. The new virtual machine(s):
+    1. Are in the correct availability zones (AZs),
+    1. Have been initialized with upgraded software,
+    1. Are prepared to pass health checks if they are functioning correctly, and;
+    1. Will fail health checks if they are not functioning correctly.
 
 ## See Also
 - [Runbooks](./README.md)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -4,6 +4,7 @@ This runbook explains how to take a new set of virtual machines (VMs) running up
 ### Index
 1. [Prerequisites](#prerequisites)
 1. [Steps](#steps)
+1. [Next Steps](#next-steps)
 1. [See Also](#see-also)
 
 ## Prerequisites
@@ -41,6 +42,9 @@ Here are the steps to take a new set of virtual machines (VMs) running upgraded 
     - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke test. After the smoke test, you can disconnect.
 
 Repeat this process for the other regions.
+
+## Next Steps
+You may want to leave the outdated virtual machines (VMs) up for 12-24 hours in case there is an issue with the upgrade and you need to rollback. The process to rollback is the same as the upgrade process, where the VMs running the previous version are added and the VMs running the current version are removed. After a sufficient amount of time with no reported issues using the upgraded software, the VMs running outdated software should be terminated to minimize costs.
 
 ## See Also
 - [Runbooks](./README.md)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -47,5 +47,8 @@ Repeat this process for the other regions.
 You may want to leave the outdated virtual machines (VMs) up for 12-24 hours in case there is an issue with the upgrade and you need to rollback. The process to rollback is the same as the upgrade process, where the VMs running the previous version are added and the VMs running the current version are removed. After a sufficient amount of time with no reported issues using the upgraded software, the VMs running outdated software should be terminated to minimize costs.
 
 ## See Also
+- EOS-EVM [Cloud Infrastructure](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/README.md)
+    - [Availability Zones](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md)
+    - [Regions](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md)
 - [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code
 - [Runbooks](./README.md)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -49,4 +49,3 @@ You may want to leave the outdated virtual machines (VMs) up for 12-24 hours in 
 ## See Also
 - [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code
 - [Runbooks](./README.md)
-    - [Upgrade Runbooks](./README.md#upgrades)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -21,24 +21,39 @@ This runbook is based on several assumptions that must be met.
 Here are the steps to take a new set of virtual machines (VMs) running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
 1. Login to the [AWS web console](https://console.aws.amazon.com).
 1. Switch to the intended [region in AWS](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md).
+    ![1](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/91370d24-6668-4993-ab1e-ef127b370dd2)
 1. Perform all smoke tests on the existing endpoint to verify everything is working before making any changes.
+    ![2](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/cf1405c5-2183-4616-bde2-515bd17f0431)
     - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke tests. After the smoke tests, you can disconnect.
 1. Perform all relevant smoke tests on each and every individual virtual machine to verify the new virtual machines are working as expected.
 1. [EC2](https://console.aws.amazon.com/ec2/home) > Target Groups > `${TARGET_GROUP_NAME}` > Targets > Register targets
+    ![3](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/66582579-eac3-4583-9ac1-473f179444b6)
     - For example, if you are upgrading the testnet RPC API in the Asia-Pacific datacenter, `${TARGET_GROUP_NAME}` might be `evm-testnet-ap-api-tg`.
 1. Under "Available instances," check the instances with the upgraded software.
+    ![4](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/fc5b5364-c5a3-4201-aa0b-6dc6a9e3f907)
     - Following the previous example, `evm-testnet-ap-api-vm-1-v0.4.1` and `evm-testnet-ap-api-vm-2-v0.4.1`.
 1. Click "Include as pending below."
+    ![5](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/8a2bc028-a5e2-4eae-83e9-9886d11b8e68)
 1. Verify the upgraded virtual machines (VMs) appear in "Review targets," then click "Register pending targets."
-1. Wait for the "Health status" column of the new instances to change from "initial" to "healthy."
+    ![6](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/5d870711-107a-4bd9-af27-494b6076ac90)
+1. The "Health status" column of the new instances will be "initial."
+    ![7](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/c4f0b5d0-e938-46e0-a0ff-8ec41abf7c0c)
+    Wait for the "Health status" column of the new instances to change from "initial" to "healthy."
+    ![8](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/f5af43ed-c67b-49d8-942c-ee8695a652d0)
 	- This took about one minute for me.
 	- If the health status changes to "unhealthy," or anything besides "healthy," stop here and escalate the situation! We need to investigate further.
 1. Under "Registered targets," check the VMs that are running the outdated software.
+    ![9](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/1678635d-06c2-4ad1-a6a3-53f241261570)
 1. Click "Deregister."
-1. The "Health status" column of the old instances will be "draining." Wait until these instances disappear.
+    ![A](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/3c44c332-f425-46d6-ba82-e112168af2f2)
+1. The "Health status" column of the old instances will be "draining."
+    ![B](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/a5a035d8-994a-41aa-b3e7-13ccd46e75e9)
+    Wait until these old instances disappear.
+    ![C](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/53e9659a-1221-4469-bc1f-9583155b6950)
 	- This took a long time for me, maybe ten minutes.
 	- This process is where AWS verifies no traffic is being routed to these instances before removing them.
 1. Perform a smoke test on the public endpoint to verify everything is working.
+    ![D](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/7b59981d-d91d-453c-92dd-1c8290b89461)
     - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke test. After the smoke test, you can disconnect.
 
 Repeat this process for the other regions.

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -47,5 +47,6 @@ Repeat this process for the other regions.
 You may want to leave the outdated virtual machines (VMs) up for 12-24 hours in case there is an issue with the upgrade and you need to rollback. The process to rollback is the same as the upgrade process, where the VMs running the previous version are added and the VMs running the current version are removed. After a sufficient amount of time with no reported issues using the upgraded software, the VMs running outdated software should be terminated to minimize costs.
 
 ## See Also
+- [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code
 - [Runbooks](./README.md)
     - [Upgrade Runbooks](./README.md#upgrades)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -14,8 +14,8 @@ This runbook is based on several assumptions that must be met.
 1. The new virtual machine(s):
     1. Are in the correct [availability zones](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md) (AZs),
     1. Have been initialized with upgraded software,
-    1. Are prepared to pass health checks if they are functioning correctly, and;
-    1. Will fail health checks if they are not functioning correctly.
+    1. Are prepared to pass [health checks](../endpoint-health-checks.md) if they are functioning correctly, and;
+    1. Will fail [health checks](../endpoint-health-checks.md) if they are not functioning correctly.
 
 ## Steps
 Here are the steps to take a new set of virtual machines (VMs) running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -1,0 +1,9 @@
+# Endpoint Network Switcharoo
+This runbook explains how to take an new set of virtual machines running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
+
+### Index
+1. [See Also](#see-also)
+
+## See Also
+- [Runbooks](./README.md)
+    - [Upgrade Runbooks](./README.md#upgrades)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -49,6 +49,7 @@ You may want to leave the outdated virtual machines (VMs) up for 12-24 hours in 
 ## See Also
 - EOS-EVM [Cloud Infrastructure](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/README.md)
     - [Availability Zones](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md)
+    - [Endpoint Health Checks](../endpoint-health-checks.md)
     - [Regions](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md)
 - [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code
 - [Runbooks](./README.md)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -3,6 +3,7 @@ This runbook explains how to take a new set of virtual machines (VMs) running up
 
 ### Index
 1. [Prerequisites](#prerequisites)
+1. [Steps](#steps)
 1. [See Also](#see-also)
 
 ## Prerequisites
@@ -14,6 +15,32 @@ This runbook is based on several assumptions that must be met.
     1. Have been initialized with upgraded software,
     1. Are prepared to pass health checks if they are functioning correctly, and;
     1. Will fail health checks if they are not functioning correctly.
+
+## Steps
+Here are the steps to take a new set of virtual machines (VMs) running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
+1. Login to the [AWS web console](https://console.aws.amazon.com).
+1. Switch to the intended region in AWS.
+1. Perform a smoke test on the existing endpoint to verify everything is working before making any changes.
+    - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke test. After the smoke test, you can disconnect.
+1. Perform a smoke test on each and every individual virtual machine to verify the new virtual machines are working as expected.
+1. [EC2](https://console.aws.amazon.com/ec2/home) > Target Groups > `${TARGET_GROUP_NAME}` > Targets > Register targets
+    - For example, if you are upgrading the testnet RPC API in the Asia-Pacific datacenter, `${TARGET_GROUP_NAME}` might be `evm-testnet-ap-api-tg`.
+1. Under "Available instances," check the instances with the upgraded software.
+    - Following the previous example, `evm-testnet-ap-api-vm-1-v0.4.1` and `evm-testnet-ap-api-vm-2-v0.4.1`.
+1. Click "Include as pending below."
+1. Verify the upgraded virtual machines (VMs) appear in "Review targets," then click "Register pending targets."
+1. Wait for the "Health status" column of the new instances to change from "initial" to "healthy."
+	- This took about one minute for me.
+	- If the health status changes to "unhealthy," or anything besides "healthy," stop here and escalate the situation! We need to investigate further.
+1. Under "Registered targets," check the VMs that are running the outdated software.
+1. Click "Deregister."
+1. The "Health status" column of the old instances will be "draining." Wait until these instances disappear.
+	- This took a long time for me, maybe ten minutes.
+	- This process is where AWS verifies no traffic is being routed to these instances before removing them.
+1. Perform a smoke test on the public endpoint to verify everything is working.
+    - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke test. After the smoke test, you can disconnect.
+
+Repeat this process for the other regions.
 
 ## See Also
 - [Runbooks](./README.md)

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -21,9 +21,9 @@ This runbook is based on several assumptions that must be met.
 Here are the steps to take a new set of virtual machines (VMs) running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
 1. Login to the [AWS web console](https://console.aws.amazon.com).
 1. Switch to the intended [region in AWS](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md).
-1. Perform a smoke test on the existing endpoint to verify everything is working before making any changes.
-    - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke test. After the smoke test, you can disconnect.
-1. Perform a smoke test on each and every individual virtual machine to verify the new virtual machines are working as expected.
+1. Perform all smoke tests on the existing endpoint to verify everything is working before making any changes.
+    - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke tests. After the smoke tests, you can disconnect.
+1. Perform all relevant smoke tests on each and every individual virtual machine to verify the new virtual machines are working as expected.
 1. [EC2](https://console.aws.amazon.com/ec2/home) > Target Groups > `${TARGET_GROUP_NAME}` > Targets > Register targets
     - For example, if you are upgrading the testnet RPC API in the Asia-Pacific datacenter, `${TARGET_GROUP_NAME}` might be `evm-testnet-ap-api-tg`.
 1. Under "Available instances," check the instances with the upgraded software.

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -1,5 +1,5 @@
 # Endpoint Network Switcharoo
-This runbook explains how to take an new set of virtual machines running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
+This runbook explains how to take a new set of virtual machines running upgraded software for one of our endpoints, deploy them to the endpoint, then remove the existing set of virtual machines running outdated software from our endpoints...ideally with zero downtime for our customers.
 
 ### Index
 1. [Prerequisites](#prerequisites)


### PR DESCRIPTION
From evm-public-docs [issue 3](https://github.com/eosnetworkfoundation/evm-public-docs/issues/3), this pull request introduces a runbook explaining how to perform a "switcharoo" to point the EOS-EVM network infrastructure from an endpoint running a previous version of our software to an endpoint running the latest version of our software, ideally without any downtime.

Preview it [here](https://github.com/eosnetworkfoundation/evm-public-docs/blob/zach-runbook/runbooks/endpoint-network-switcharoo.md).

## See Also
1. evm-public-docs [issue 3](https://github.com/eosnetworkfoundation/evm-public-docs/issues/3) - Write EVM Endpoint Upgrade Runbook
    1. eos-evm-internal [pull request 17](https://github.com/eosnetworkfoundation/eos-evm-internal/pull/17) - Document AWS Regions and AZs
    1. evm-public-docs [pull request 5](https://github.com/eosnetworkfoundation/evm-public-docs/pull/5) - Document Network Endpoint Health Checks
    1. evm-public-docs [pull request 4](https://github.com/eosnetworkfoundation/evm-public-docs/pull/4) - EVM Endpoint Network Switcharoo Runbook
    1. evm-public-docs [pull request 6](https://github.com/eosnetworkfoundation/evm-public-docs/pull/6) - Document Network Endpoint Smoke Tests
