### PR TITLE
Document Network Endpoint Health Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# evm-public-docs
+# EOS-EVM Public Documentation
 EOS-EVM-related documents for the public.
 
 ## multisig contract deployment:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # evm-public-docs
-EVM related documents for the public
-
+EOS-EVM-related documents for the public.
 
 ## multisig contract deployment:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ EOS-EVM-related documents for the public.
 ## Multisig Contract Deployment
 Documentation around deploying the EOS-EVM.
 
-### multisig account creation of eosio.evm: 
-please refer to https://github.com/eosnetworkfoundation/evm-public-docs/blob/main/msig_contract_deployment/msig_account_creation.md
+### Multisig Account Creation of eosio.evm
+Please refer to [msig_contract_deployment/msig_account_creation.md](https://github.com/eosnetworkfoundation/evm-public-docs/blob/main/msig_contract_deployment/msig_account_creation.md).
 
-### multisig EVM contract bootstrapping: 
-please refer to https://github.com/eosnetworkfoundation/evm-public-docs/blob/main/msig_contract_deployment/msig_evm_bootstrap.md
+### Multisig EVM Contract Bootstrapping
+Please refer to [msig_contract_deployment/msig_evm_bootstrap.md](https://github.com/eosnetworkfoundation/evm-public-docs/blob/main/msig_contract_deployment/msig_evm_bootstrap.md).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ EOS-EVM-related documents for the public.
     1. [Multisig Account Creation of eosio.evm](./msig_contract_deployment/msig_account_creation.md)
     1. [Multisig EVM Contract Bootstrapping](./msig_contract_deployment/msig_evm_bootstrap.md)
 1. [Endpoints](#endpoints)
+    1. [Endpoint Health Checks](./endpoint-health-checks.md)
 
 ## Contract Deployment
 Documentation around deploying the EOS-EVM.
@@ -18,3 +19,6 @@ Please refer to [msig_contract_deployment/msig_evm_bootstrap.md](https://github.
 
 ## Endpoints
 Documentation about EOS-EVM web endpoints.
+
+### Endpoint Health Checks
+Tests used to determine if endpoints are healthy are [here](./endpoint-health-checks.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # EOS-EVM Public Documentation
 EOS-EVM-related documents for the public.
 
+### Index
+1. [Multisig Contract Deployment](#multisig-contract-deployment)
+    1. [Multisig Account Creation of eosio.evm](./msig_contract_deployment/msig_account_creation.md)
+    1. [Multisig EVM Contract Bootstrapping](./msig_contract_deployment/msig_evm_bootstrap.md)
+
 ## Multisig Contract Deployment
 Documentation around deploying the EOS-EVM.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 EOS-EVM-related documents for the public.
 
 ### Index
-1. [Multisig Contract Deployment](#multisig-contract-deployment)
+1. [Contract Deployment](#multisig-contract-deployment)
     1. [Multisig Account Creation of eosio.evm](./msig_contract_deployment/msig_account_creation.md)
     1. [Multisig EVM Contract Bootstrapping](./msig_contract_deployment/msig_evm_bootstrap.md)
 
-## Multisig Contract Deployment
+## Contract Deployment
 Documentation around deploying the EOS-EVM.
 
 ### Multisig Account Creation of eosio.evm

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # EOS-EVM Public Documentation
 EOS-EVM-related documents for the public.
 
-## multisig contract deployment:
+## Multisig Contract Deployment
+Documentation around deploying the EOS-EVM.
 
 ### multisig account creation of eosio.evm: 
 please refer to https://github.com/eosnetworkfoundation/evm-public-docs/blob/main/msig_contract_deployment/msig_account_creation.md

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ EOS-EVM-related documents for the public.
 1. [Contract Deployment](#multisig-contract-deployment)
     1. [Multisig Account Creation of eosio.evm](./msig_contract_deployment/msig_account_creation.md)
     1. [Multisig EVM Contract Bootstrapping](./msig_contract_deployment/msig_evm_bootstrap.md)
+1. [Endpoints](#endpoints)
 
 ## Contract Deployment
 Documentation around deploying the EOS-EVM.
@@ -14,3 +15,6 @@ Please refer to [msig_contract_deployment/msig_account_creation.md](https://gith
 
 ### Multisig EVM Contract Bootstrapping
 Please refer to [msig_contract_deployment/msig_evm_bootstrap.md](https://github.com/eosnetworkfoundation/evm-public-docs/blob/main/msig_contract_deployment/msig_evm_bootstrap.md).
+
+## Endpoints
+Documentation about EOS-EVM web endpoints.

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -47,3 +47,10 @@ The EOS-EVM RPC API is considered healthy if it returns a 200-299 status code at
 - 5 second timeout
 - Two consecutive failure threshold to transition to "unhealthy"
 - Five consecutive success threshold to transition to "healthy"
+
+***
+**_Legal notice_**  
+This document was generated in collaboration with ChatGPT from OpenAI, a machine learning algorithm or weak artificial intelligence (AI). At the time of this writing, the [OpenAI terms of service agreement](https://openai.com/terms) §3.a states:
+> Your Content. You may provide input to the Services (“Input”), and receive output generated and returned by the Services based on the Input (“Output”). Input and Output are collectively “Content.” As between the parties and to the extent permitted by applicable law, you own all Input, and subject to your compliance with these Terms, OpenAI hereby assigns to you all its right, title and interest in and to Output.
+
+This notice is required in some countries.

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -4,6 +4,7 @@ This document describes the health checks we are using for the EOS-EVM endpoint 
 ### Index
 1. [Health Check Definition](#health-check-definition)
 1. [Bridge](#bridge)
+1. [Explorer](#explorer)
 
 ## Health Check Definition
 What is a health check?
@@ -19,3 +20,6 @@ What is a health check?
 
 ## Bridge
 The EOS-EVM bridge is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/.
+
+## Explorer
+The EOS-EVM explorer is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/.

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -6,6 +6,7 @@ This document describes the health checks we are using for the EOS-EVM endpoint 
 1. [Bridge](#bridge)
 1. [Explorer](#explorer)
 1. [Faucet](#faucet)
+1. [RPC API](#rpc-api)
 
 ## Health Check Definition
 What is a health check?
@@ -27,3 +28,6 @@ The EOS-EVM explorer is currently determined to be healthy if it returns a 200-2
 
 ## Faucet
 The EOS-EVM faucet is currently only available on the testnet, and is hosted by EOS-Nation. We do not currently have health checks for their faucet.
+
+## RPC API
+The EOS-EVM RPC API is considered healthy if it returns a 200-299 status code at HTTP:8000/.

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -21,13 +21,29 @@ What is a health check?
 > Health checks are crucial for maintaining the operational efficiency and resilience of cloud infrastructure, as they help identify and address potential problems proactively. By continuously monitoring the health of the resources, cloud operators can ensure optimal performance and minimize downtime, leading to improved service quality for users or customers.
 
 ## Bridge
-The EOS-EVM bridge is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/.
+The EOS-EVM bridge is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/. We are using the default Amazon Web Services (AWS) health check parameters which, at the time of this writing, are:
+- 30 second interval
+- 5 second timeout
+- Two consecutive failure threshold to transition to "unhealthy"
+- Five consecutive success threshold to transition to "healthy"
 
 ## Explorer
-The EOS-EVM explorer is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/.
+The EOS-EVM explorer is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/. We are using the default Amazon Web Services (AWS) health check parameters which, at the time of this writing, are:
+- 30 second interval
+- 5 second timeout
+- Two consecutive failure threshold to transition to "unhealthy"
+- Five consecutive success threshold to transition to "healthy"
 
 ## Faucet
-The EOS-EVM faucet is currently only available on the testnet, and is hosted by EOS-Nation. We do not currently have health checks for their faucet.
+The EOS-EVM faucet is currently only available on the testnet, and is hosted by EOS-Nation. We are using the default Amazon Web Services (AWS) health check parameters which, at the time of this writing, are:
+- 30 second interval
+- 5 second timeout
+- Two consecutive failure threshold to transition to "unhealthy"
+- Five consecutive success threshold to transition to "healthy"
 
 ## RPC API
-The EOS-EVM RPC API is considered healthy if it returns a 200-299 status code at HTTP:8000/.
+The EOS-EVM RPC API is considered healthy if it returns a 200-299 status code at HTTP:8000/. We are using the default Amazon Web Services (AWS) health check parameters which, at the time of this writing, are:
+- 30 second interval
+- 5 second timeout
+- Two consecutive failure threshold to transition to "unhealthy"
+- Five consecutive success threshold to transition to "healthy"

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -1,0 +1,17 @@
+# Endpoint Health Checks
+This document describes the health checks we are using for the EOS-EVM endpoint infrastructure.
+
+### Index
+1. [Health Check Definition](#health-check-definition)
+
+## Health Check Definition
+What is a health check?
+> In the context of cloud infrastructure, a health check refers to a monitoring mechanism that assesses the status and availability of various components within a cloud-based system. It is commonly used to ensure that the cloud resources, such as virtual machines, load balancers, databases, or applications, are functioning properly and able to handle incoming requests.
+>
+> Health checks are typically performed at regular intervals by an automated process or a dedicated monitoring service. The checks are designed to verify the responsiveness and performance of the infrastructure components. The specific criteria and tests involved in a health check can vary depending on the nature of the resource being monitored.
+>
+> During a health check, the system typically sends requests or probes to the resources being monitored and analyzes the responses received. The health check process may examine factors such as response times, error rates, network connectivity, and overall availability. By evaluating these parameters, the system can determine whether the resource is functioning correctly or if there are any issues that need attention.
+>
+> The results of health checks are used to make informed decisions about managing the cloud infrastructure. For example, if a health check identifies a component that is not responding or is experiencing performance issues, it can trigger an automatic response, such as restarting the resource or diverting traffic to alternative resources to maintain the overall availability and reliability of the system.
+>
+> Health checks are crucial for maintaining the operational efficiency and resilience of cloud infrastructure, as they help identify and address potential problems proactively. By continuously monitoring the health of the resources, cloud operators can ensure optimal performance and minimize downtime, leading to improved service quality for users or customers.

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -5,6 +5,7 @@ This document describes the health checks we are using for the EOS-EVM endpoint 
 1. [Health Check Definition](#health-check-definition)
 1. [Bridge](#bridge)
 1. [Explorer](#explorer)
+1. [Faucet](#faucet)
 
 ## Health Check Definition
 What is a health check?
@@ -23,3 +24,6 @@ The EOS-EVM bridge is currently determined to be healthy if it returns a 200-299
 
 ## Explorer
 The EOS-EVM explorer is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/.
+
+## Faucet
+The EOS-EVM faucet is currently only available on the testnet, and is hosted by EOS-Nation. We do not currently have health checks for their faucet.

--- a/endpoint-health-checks.md
+++ b/endpoint-health-checks.md
@@ -3,6 +3,7 @@ This document describes the health checks we are using for the EOS-EVM endpoint 
 
 ### Index
 1. [Health Check Definition](#health-check-definition)
+1. [Bridge](#bridge)
 
 ## Health Check Definition
 What is a health check?
@@ -15,3 +16,6 @@ What is a health check?
 > The results of health checks are used to make informed decisions about managing the cloud infrastructure. For example, if a health check identifies a component that is not responding or is experiencing performance issues, it can trigger an automatic response, such as restarting the resource or diverting traffic to alternative resources to maintain the overall availability and reliability of the system.
 >
 > Health checks are crucial for maintaining the operational efficiency and resilience of cloud infrastructure, as they help identify and address potential problems proactively. By continuously monitoring the health of the resources, cloud operators can ensure optimal performance and minimize downtime, leading to improved service quality for users or customers.
+
+## Bridge
+The EOS-EVM bridge is currently determined to be healthy if it returns a 200-299 status code at HTTP:80/.


### PR DESCRIPTION
From evm-public-docs [issue 3](https://github.com/eosnetworkfoundation/evm-public-docs/issues/3), this pull request documents the health checks being used to determine if network endpoints are available for traffic.

## See Also
- evm-public-docs [issue 3](https://github.com/eosnetworkfoundation/evm-public-docs/issues/3) - Write EVM Endpoint Upgrade Runbook
- evm-public-docs [pull request 4](https://github.com/eosnetworkfoundation/evm-public-docs/pull/4) - EVM Endpoint Network Switcharoo Runbook
- evm-public-docs [pull request 5](https://github.com/eosnetworkfoundation/evm-public-docs/pull/5) - Document Network Endpoint Health Checks
- evm-public-docs [pull request 6](https://github.com/eosnetworkfoundation/evm-public-docs/pull/6) - Document Network Endpoint Smoke Tests
- eos-evm-internal [pull request 17](https://github.com/eosnetworkfoundation/eos-evm-internal/pull/17) - Document AWS Regions and AZs
