### PR TITLE
Document Network Endpoint Smoke Tests

### DIFF
--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -13,6 +13,7 @@ Our runbooks are as open as possible in the interest of transparency. However, r
 ## Upgrades
 Runbooks for upgrading EOS-EVM components and infrastructure.
 1. Endpoint Upgrade
+    1. [Endpoint Smoke Test](./endpoint-smoke-test.md) - validate a given EOS-EVM network endpoint is online, functional, and qualified to receive public traffic
     1. [Endpoint Network Switcharoo](./endpoint-network-switcharoo.md) - deploy a set of virtual machines with upgraded software to our endpoints
 
 ## See Also

--- a/runbooks/endpoint-network-switcharoo.md
+++ b/runbooks/endpoint-network-switcharoo.md
@@ -22,10 +22,10 @@ Here are the steps to take a new set of virtual machines (VMs) running upgraded 
 1. Login to the [AWS web console](https://console.aws.amazon.com).
 1. Switch to the intended [region in AWS](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md).
     ![1](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/91370d24-6668-4993-ab1e-ef127b370dd2)
-1. Perform all smoke tests on the existing endpoint to verify everything is working before making any changes.
+1. Perform all [smoke tests](./endpoint-smoke-test.md) on the existing endpoint to verify everything is working before making any changes.
     ![2](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/cf1405c5-2183-4616-bde2-515bd17f0431)
-    - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the smoke tests. After the smoke tests, you can disconnect.
-1. Perform all relevant smoke tests on each and every individual virtual machine to verify the new virtual machines are working as expected.
+    - To guarantee your traffic is being served from these endpoints, use a public virtual private network (VPN) to connect to this part of the world for the [smoke tests](./endpoint-smoke-test.md). After the [smoke tests](./endpoint-smoke-test.md), you can disconnect.
+1. Perform all relevant [smoke tests](./endpoint-smoke-test.md) on each and every individual virtual machine to verify the new virtual machines are working as expected.
 1. [EC2](https://console.aws.amazon.com/ec2/home) > Target Groups > `${TARGET_GROUP_NAME}` > Targets > Register targets
     ![3](https://github.com/eosnetworkfoundation/evm-public-docs/assets/34947245/66582579-eac3-4583-9ac1-473f179444b6)
     - For example, if you are upgrading the testnet RPC API in the Asia-Pacific datacenter, `${TARGET_GROUP_NAME}` might be `evm-testnet-ap-api-tg`.
@@ -65,6 +65,7 @@ You may want to leave the outdated virtual machines (VMs) up for 12-24 hours in 
 - EOS-EVM [Cloud Infrastructure](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/README.md)
     - [Availability Zones](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md)
     - [Endpoint Health Checks](../endpoint-health-checks.md)
+    - [Endpoint Smoke Tests](./endpoint-smoke-test.md)
     - [Regions](https://github.com/eosnetworkfoundation/eos-evm-internal/blob/main/cloud/aws-region.md)
 - [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code
 - [Runbooks](./README.md)

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -38,7 +38,7 @@ Smoke tests for the RPC API.
 1. Verify the RPC API returns the head block.
     - Mainnet
       ```bash
-      curl -fsSL 'https://api.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      curl -fsSL 'https://api.evm.eosnetwork.com' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
       ```
       You should see something like this, where the `result` field will vary by incrementing once per second.
       ```json
@@ -50,7 +50,7 @@ Smoke tests for the RPC API.
       ```
     - Testnet
       ```bash
-      curl -fsSL 'https://api.testnet.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      curl -fsSL 'https://api.testnet.evm.eosnetwork.com' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
       ```
       You should see something like this, where the `result` field will vary by incrementing once per second.
       ```json
@@ -63,7 +63,7 @@ Smoke tests for the RPC API.
 1. Verify the RPC API rejects unencrypted requests.
     - Mainnet
       ```bash
-      curl -fsSL 'http://api.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      curl -fsSL 'http://api.evm.eosnetwork.com' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
       ```
       Currently, we expect you to get a 500 response.
       ```
@@ -71,7 +71,7 @@ Smoke tests for the RPC API.
       ```
     - Testnet
       ```bash
-      curl -fsSL 'http://api.testnet.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      curl -fsSL 'http://api.testnet.evm.eosnetwork.com' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
       ```
       Currently, we expect you to get a 500 response.
       ```

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -1,2 +1,11 @@
 # Endpoint Smoke Test
 This documents the process to validate a given EOS-EVM network endpoint is online, functional, and qualified to receive public traffic.
+
+### Index
+1. [Bridge](#bridge)
+
+## Bridge
+Smoke tests for the bridge.
+1. Navigate to the bridge in your web browser and verify it loads.
+    - [bridge.evm.eosnetwork.com](https://bridge.evm.eosnetwork.com)
+    - [bridge.testnet.evm.eosnetwork.com](https://bridge.testnet.evm.eosnetwork.com)

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -4,6 +4,7 @@ This documents the process to validate a given EOS-EVM network endpoint is onlin
 ### Index
 1. [Bridge](#bridge)
 1. [Explorer](#explorer)
+1. [Faucet](#faucet)
 
 ## Bridge
 Smoke tests for the bridge.
@@ -16,3 +17,8 @@ Smoke tests for the explorer.
 1. Navigate to the explorer in your web browser and verify it loads.
     - [explorer.evm.eosnetwork.com](https://explorer.evm.eosnetwork.com)
     - [explorer.testnet.evm.eosnetwork.com](https://explorer.testnet.evm.eosnetwork.com)
+
+## Faucet
+Smoke tests for the faucet.
+1. Navigate to the faucet in your web browser and verify it loads.
+    - [faucet.testnet.evm.eosnetwork.com](https://faucet.testnet.evm.eosnetwork.com)

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -12,17 +12,25 @@ Smoke tests for the bridge.
 1. Navigate to the bridge in your web browser and verify it loads.
     - [bridge.evm.eosnetwork.com](https://bridge.evm.eosnetwork.com)
     - [bridge.testnet.evm.eosnetwork.com](https://bridge.testnet.evm.eosnetwork.com)
+1. Verify the endpoint redirects your web browser from HTTP to HTTPS when attempting to load it unencrypted.
+    - [bridge.evm.eosnetwork.com](http://bridge.evm.eosnetwork.com)
+    - [bridge.testnet.evm.eosnetwork.com](http://bridge.testnet.evm.eosnetwork.com)
 
 ## Explorer
 Smoke tests for the explorer.
 1. Navigate to the explorer in your web browser and verify it loads.
     - [explorer.evm.eosnetwork.com](https://explorer.evm.eosnetwork.com)
     - [explorer.testnet.evm.eosnetwork.com](https://explorer.testnet.evm.eosnetwork.com)
+1. Verify the endpoint redirects your web browser from HTTP to HTTPS when attempting to load it unencrypted.
+    - [explorer.evm.eosnetwork.com](http://explorer.evm.eosnetwork.com)
+    - [explorer.testnet.evm.eosnetwork.com](http://explorer.testnet.evm.eosnetwork.com)
 
 ## Faucet
 Smoke tests for the faucet.
 1. Navigate to the faucet in your web browser and verify it loads.
     - [faucet.testnet.evm.eosnetwork.com](https://faucet.testnet.evm.eosnetwork.com)
+1. Verify the endpoint redirects your web browser from HTTP to HTTPS when attempting to load it unencrypted.
+    - [faucet.testnet.evm.eosnetwork.com](http://faucet.testnet.evm.eosnetwork.com)
 
 ## RPC API
 Smoke tests for the RPC API.

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -3,9 +3,16 @@ This documents the process to validate a given EOS-EVM network endpoint is onlin
 
 ### Index
 1. [Bridge](#bridge)
+1. [Explorer](#explorer)
 
 ## Bridge
 Smoke tests for the bridge.
 1. Navigate to the bridge in your web browser and verify it loads.
     - [bridge.evm.eosnetwork.com](https://bridge.evm.eosnetwork.com)
     - [bridge.testnet.evm.eosnetwork.com](https://bridge.testnet.evm.eosnetwork.com)
+
+## Explorer
+Smoke tests for the explorer.
+1. Navigate to the explorer in your web browser and verify it loads.
+    - [explorer.evm.eosnetwork.com](https://explorer.evm.eosnetwork.com)
+    - [explorer.testnet.evm.eosnetwork.com](https://explorer.testnet.evm.eosnetwork.com)

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -5,6 +5,7 @@ This documents the process to validate a given EOS-EVM network endpoint is onlin
 1. [Bridge](#bridge)
 1. [Explorer](#explorer)
 1. [Faucet](#faucet)
+1. [RPC API](#rpc-api)
 
 ## Bridge
 Smoke tests for the bridge.
@@ -22,3 +23,31 @@ Smoke tests for the explorer.
 Smoke tests for the faucet.
 1. Navigate to the faucet in your web browser and verify it loads.
     - [faucet.testnet.evm.eosnetwork.com](https://faucet.testnet.evm.eosnetwork.com)
+
+## RPC API
+Smoke tests for the RPC API.
+1. Verify the RPC API returns the head block.
+    - Mainnet
+      ```bash
+      curl -fsSL https://api.evm.eosnetwork.com/v3 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      ```
+      You should see something like this, where the `result` field will vary by incrementing once per second.
+      ```json
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": "0x39bdd8"
+      }
+      ```
+    - Testnet
+      ```bash
+      curl -fsSL https://api.testnet.evm.eosnetwork.com/v3 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      ```
+      You should see something like this, where the `result` field will vary by incrementing once per second.
+      ```json
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": "0x39bdd8"
+      }
+      ```

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -59,3 +59,20 @@ Smoke tests for the RPC API.
         "result": "0x39bdd8"
       }
       ```
+1. Verify the RPC API rejects unencrypted requests.
+    - Mainnet
+      ```bash
+      curl -fsSL 'http://api.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      ```
+      Currently, we expect you to get a 500 response.
+      ```
+      curl: (22) The requested URL returned error: 500
+      ```
+    - Testnet
+      ```bash
+      curl -fsSL 'http://api.testnet.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      ```
+      Currently, we expect you to get a 500 response.
+      ```
+      curl: (22) The requested URL returned error: 500
+      ```

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -37,7 +37,7 @@ Smoke tests for the RPC API.
 1. Verify the RPC API returns the head block.
     - Mainnet
       ```bash
-      curl -fsSL https://api.evm.eosnetwork.com/v3 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      curl -fsSL 'https://api.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
       ```
       You should see something like this, where the `result` field will vary by incrementing once per second.
       ```json
@@ -49,7 +49,7 @@ Smoke tests for the RPC API.
       ```
     - Testnet
       ```bash
-      curl -fsSL https://api.testnet.evm.eosnetwork.com/v3 -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
+      curl -fsSL 'https://api.testnet.evm.eosnetwork.com/v3' -X POST -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' | jq .
       ```
       You should see something like this, where the `result` field will vary by incrementing once per second.
       ```json

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -1,0 +1,2 @@
+# Endpoint Smoke Test
+This documents the process to validate a given EOS-EVM network endpoint is online, functional, and qualified to receive public traffic.

--- a/runbooks/endpoint-smoke-test.md
+++ b/runbooks/endpoint-smoke-test.md
@@ -6,6 +6,7 @@ This documents the process to validate a given EOS-EVM network endpoint is onlin
 1. [Explorer](#explorer)
 1. [Faucet](#faucet)
 1. [RPC API](#rpc-api)
+1. [See Also](#see-also)
 
 ## Bridge
 Smoke tests for the bridge.
@@ -76,3 +77,7 @@ Smoke tests for the RPC API.
       ```
       curl: (22) The requested URL returned error: 500
       ```
+
+## See Also
+- [Endpoint Health Checks](../endpoint-health-checks.md)
+- [eos-evm](https://github.com/eosnetworkfoundation/eos-evm) - core EOS Ethereum virtual machine source code


### PR DESCRIPTION
From evm-public-docs [issue 3](https://github.com/eosnetworkfoundation/evm-public-docs/issues/3), this pull request documents the smoke tests being used to manually determine if network endpoints are suitable to make available to the public.

## See Also
1. evm-public-docs [issue 3](https://github.com/eosnetworkfoundation/evm-public-docs/issues/3) - Write EVM Endpoint Upgrade Runbook
    1. eos-evm-internal [pull request 17](https://github.com/eosnetworkfoundation/eos-evm-internal/pull/17) - Document AWS Regions and AZs
    1. evm-public-docs [pull request 5](https://github.com/eosnetworkfoundation/evm-public-docs/pull/5) - Document Network Endpoint Health Checks
    1. evm-public-docs [pull request 4](https://github.com/eosnetworkfoundation/evm-public-docs/pull/4) - EVM Endpoint Network Switcharoo Runbook
    1. evm-public-docs [pull request 6](https://github.com/eosnetworkfoundation/evm-public-docs/pull/6) - Document Network Endpoint Smoke Tests
